### PR TITLE
Adds ability to use regular expressions in sets

### DIFF
--- a/src/main/config.yml
+++ b/src/main/config.yml
@@ -6,6 +6,10 @@ enabled: true
 # move items when they are moved into a sender chest by a hopper. This feature could be not safe to use! Enable with caution.
 sendFromHopper: false
 
+# allows the use of Regular Expressions in sets
+# example: '.*_log' to match all things that end with "_log"
+enableSetsRegex: false
+
 # define sets if you want similar items to be moved to just one chest
 # look at the examples if you want to add a new set.
 # define a new array by beginning the line with - []

--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
@@ -107,12 +107,10 @@ class ItemChestSorter: JavaPlugin() {
                 })
             }
             // returns the matching set
-            val match = setsRegex.firstOrNull { s ->
+            return setsRegex.any { s ->
                 (s.any { p -> p.containsMatchIn(itemInChest.type.key.key) }
                 && s.any { p -> p.containsMatchIn(itemInItemFrame.type.key.key) })
             }
-
-            return match != null
         }else{
             for (set in sets) {
                 if(set.contains(itemInChest.type.key.key) && set.contains(itemInItemFrame.type.key.key)) {

--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
@@ -95,17 +95,23 @@ class ItemChestSorter: JavaPlugin() {
      * @author Flo Dörr
      */
     fun isItemInSet(itemInChest: ItemStack, itemInItemFrame: ItemStack): Boolean {
-        val sets = getSets()        
+        val sets = getSets()
+
         if(this.config.getBoolean("enabled") == true) {
             if(setsRegex.count() == 0){
                 // Keeps regex in buffer
-                setsRegex = ArrayList(sets.map { set -> ArrayList(set.map { p -> p.toRegex(RegexOption.IGNORE_CASE)})})
+                setsRegex = ArrayList(sets.map {
+                    set -> ArrayList(set.map {
+                        p -> p.toRegex(RegexOption.IGNORE_CASE)
+                    })
+                })
             }
             // returns the matching set
-            var match = setsRegex.firstOrNull { s -> 
-                (s.any { p -> p.containsMatchIn(itemInChest.type.key.key) } 
+            var match = setsRegex.firstOrNull { s ->
+                (s.any { p -> p.containsMatchIn(itemInChest.type.key.key) }
                 && s.any { p -> p.containsMatchIn(itemInItemFrame.type.key.key) })
             }
+
             return match != null;
         }else{
             for (set in sets) {
@@ -114,7 +120,7 @@ class ItemChestSorter: JavaPlugin() {
                 }
             }
         }
-        
+
         return false
     }
 }

--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
@@ -97,7 +97,7 @@ class ItemChestSorter: JavaPlugin() {
     fun isItemInSet(itemInChest: ItemStack, itemInItemFrame: ItemStack): Boolean {
         val sets = getSets()
 
-        if(this.config.getBoolean("enableSetsRegex") == true) {
+        if(this.config.getBoolean("enableSetsRegex", false)) {
             if(setsRegex.count() == 0){
                 // Keeps regex in buffer
                 setsRegex = ArrayList(sets.map {

--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
@@ -9,7 +9,8 @@ import java.nio.file.Paths
 class ItemChestSorter: JavaPlugin() {
 
     private lateinit var db: JsonHelper
-
+    private var setsRegex = ArrayList<ArrayList<Regex>>()
+    
     override fun onEnable() {
         super.onEnable()
 
@@ -94,12 +95,26 @@ class ItemChestSorter: JavaPlugin() {
      * @author Flo Dörr
      */
     fun isItemInSet(itemInChest: ItemStack, itemInItemFrame: ItemStack): Boolean {
-        val sets = getSets()
-        for (set in sets) {
-            if(set.contains(itemInChest.type.key.key) && set.contains(itemInItemFrame.type.key.key)) {
-                return true
+        val sets = getSets()        
+        if(this.config.getBoolean("enabled") == true) {
+            if(setsRegex.count() == 0){
+                // Keeps regex in buffer
+                setsRegex = ArrayList(sets.map { set -> ArrayList(set.map { p -> p.toRegex(RegexOption.IGNORE_CASE)})})
+            }
+            // returns the matching set
+            var match = setsRegex.firstOrNull { s -> 
+                (s.any { p -> p.containsMatchIn(itemInChest.type.key.key) } 
+                && s.any { p -> p.containsMatchIn(itemInItemFrame.type.key.key) })
+            }
+            return match != null;
+        }else{
+            for (set in sets) {
+                if(set.contains(itemInChest.type.key.key) && set.contains(itemInItemFrame.type.key.key)) {
+                    return true
+                }
             }
         }
+        
         return false
     }
 }

--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
@@ -97,7 +97,7 @@ class ItemChestSorter: JavaPlugin() {
     fun isItemInSet(itemInChest: ItemStack, itemInItemFrame: ItemStack): Boolean {
         val sets = getSets()
 
-        if(this.config.getBoolean("enabled") == true) {
+        if(this.config.getBoolean("enableSetsRegex") == true) {
             if(setsRegex.count() == 0){
                 // Keeps regex in buffer
                 setsRegex = ArrayList(sets.map {

--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
@@ -107,12 +107,12 @@ class ItemChestSorter: JavaPlugin() {
                 })
             }
             // returns the matching set
-            var match = setsRegex.firstOrNull { s ->
+            val match = setsRegex.firstOrNull { s ->
                 (s.any { p -> p.containsMatchIn(itemInChest.type.key.key) }
                 && s.any { p -> p.containsMatchIn(itemInItemFrame.type.key.key) })
             }
 
-            return match != null;
+            return match != null
         }else{
             for (set in sets) {
                 if(set.contains(itemInChest.type.key.key) && set.contains(itemInItemFrame.type.key.key)) {


### PR DESCRIPTION
Only the individual parts of the code have been tested, but I haven't compiled the whole plugin, but pretty sure this should work. 

Setting `enableSetsRegex` to `true` shouldn't have any adverse effects on existing sets since no characters need escaping so I think everything should work fine. 