### PR TITLE
Changes `.containsMatchIn()` to `.matches()` for better compatibility

### DIFF
--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/ItemChestSorter.kt
@@ -109,8 +109,8 @@ class ItemChestSorter: JavaPlugin() {
             }
             // returns the matching set
             return setsRegex.any { s ->
-                (s.any { p -> p.containsMatchIn(itemInChest.type.key.key) }
-                && s.any { p -> p.containsMatchIn(itemInItemFrame.type.key.key) })
+                (s.any { p -> p.matches(itemInChest.type.key.key) }
+                && s.any { p -> p.matches(itemInItemFrame.type.key.key) })
             }
         }else{
             for (set in sets) {


### PR DESCRIPTION
Retroactively, I realized I should always be matching the entire word, otherwise non-regex sets won't always work as expected unless everything has a `^` and `$` added to both ends of it.