### PR TITLE
Fix for sender/receiver id's failing if spaces in them

### DIFF
--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/Commands.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/Commands.kt
@@ -11,6 +11,7 @@ import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import java.util.*
+import java.net.URLDecoder
 
 
 class Commands(private val db: JsonHelper, private val ics: ItemChestSorter): CommandExecutor {
@@ -58,11 +59,12 @@ class Commands(private val db: JsonHelper, private val ics: ItemChestSorter): Co
                         args[1].lowercase(Locale.getDefault()) == "sender" -> {
                             val permission = "ics.remove.sender"
                             if (sender.hasPermission(permission)) {
-                                if (db.removeSender(args[2])) {
+                                val target = URLDecoder.decode(args[2], "UTF-8")
+                                if (db.removeSender(target)) {
                                     currentSender[(sender as Player).uniqueId.toString()] = null
                                     sender.sendMessage("${ChatColor.GREEN}Successfully deleted the sender chest.")
                                 } else {
-                                    sender.sendMessage("${ChatColor.RED}Error while deleting the sender chest with id ${args[2]}. This most likely means the id was not found.")
+                                    sender.sendMessage("${ChatColor.RED}Error while deleting the sender chest with id ${target}. This most likely means the id was not found.")
                                 }
                             } else {
                                 showNoPermissionMessage(sender, permission)
@@ -73,10 +75,11 @@ class Commands(private val db: JsonHelper, private val ics: ItemChestSorter): Co
                         args[1].lowercase(Locale.getDefault()) == "receiver" -> {
                             val permission = "ics.remove.receiver"
                             if (sender.hasPermission(permission)) {
-                                if (db.removeReceiver(args[2])) {
+                                val target = URLDecoder.decode(args[2], "UTF-8")
+                                if (db.removeReceiver(target)) {
                                     sender.sendMessage("${ChatColor.GREEN}Successfully deleted the receiver chest.")
                                 } else {
-                                    sender.sendMessage("${ChatColor.RED}Error while deleting the receiver chest with id ${args[2]}. This most likely means the id was not found.")
+                                    sender.sendMessage("${ChatColor.RED}Error while deleting the receiver chest with id ${target}. This most likely means the id was not found.")
                                 }
                             } else {
                                 showNoPermissionMessage(sender, permission)

--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/Listener.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/Listener.kt
@@ -26,6 +26,7 @@ import org.bukkit.inventory.Inventory
 import org.bukkit.inventory.ItemStack
 import org.bukkit.util.BoundingBox
 import java.util.*
+import java.net.URLEncoder
 import kotlin.collections.ArrayList
 import kotlin.concurrent.fixedRateTimer
 import kotlin.concurrent.schedule
@@ -561,7 +562,8 @@ class Listener(private val db: JsonHelper, private val main: ItemChestSorter): L
             val message = TextComponent("delete")
             message.color = net.md_5.bungee.api.ChatColor.RED
             message.isUnderlined = true
-            message.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ics remove sender ${existingSender.sid}")
+            val encodedSid = URLEncoder.encode(existingSender.sid, "UTF-8")
+            message.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ics remove sender ${encodedSid}")
             player.spigot().sendMessage(message)
         }else{
             val permission = "ics.create.sender"
@@ -647,7 +649,8 @@ class Listener(private val db: JsonHelper, private val main: ItemChestSorter): L
                         val m2 = TextComponent("click here.")
                         m2.color = net.md_5.bungee.api.ChatColor.RED
                         m2.isUnderlined = true
-                        m2.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ics remove sender ${existingChest.first!!.sid}")
+                        var encodedSid = URLEncoder.encode(existingChest.first!!.sid, "UTF-8")
+                        m2.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ics remove sender ${encodedSid}")
                         val m3 = TextComponent(" Warning! Deleting a sender chest will also delete all its receivers!")
                         m3.color = net.md_5.bungee.api.ChatColor.RED
                         m1.addExtra(m2)
@@ -666,7 +669,8 @@ class Listener(private val db: JsonHelper, private val main: ItemChestSorter): L
                         val m2 = TextComponent("click here.")
                         m2.color = net.md_5.bungee.api.ChatColor.RED
                         m2.isUnderlined = true
-                        m2.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ics remove receiver ${existingChest.second!!.rid}")
+                        var encodedRid = URLEncoder.encode(existingChest.second!!.rid, "UTF-8")
+                        m2.clickEvent = ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ics remove receiver ${encodedRid}")
                         m1.addExtra(m2)
                         player.spigot().sendMessage(m1)
                     }


### PR DESCRIPTION
While using the plugin, I realized that if a world has spaces in the name, it would have errors looking up the sender/receiver ID.  This was due to the way `onCommand` parses the commands into separate arguments based on the spaces.  This fix uses URLEncode/URLDecode to ensure the IDs are passed around in commands in a single argument.

Why URL encode/decode? I could have just just merged all arguments to rebuild the ID, but this means the very last argument must be the ID, or it wont work.  Using URL encoding the order of arguments becomes irrelevant, and future commands wont have to solve this problem either.