### PR TITLE
Behavior tweak - have chests show particles if do not have item frame

### DIFF
--- a/src/main/kotlin/com/flodoerr/item_chest_sorter/Listener.kt
+++ b/src/main/kotlin/com/flodoerr/item_chest_sorter/Listener.kt
@@ -198,6 +198,8 @@ class Listener(private val db: JsonHelper, private val main: ItemChestSorter): L
                                         val message = "${ChatColor.YELLOW}There is a receiver chest which has no item frame on it. Please put an item frame on a receiver chest, containing the target item/block. You can also leave the item frame empty to accept all items which could not be sorted."
                                         if(player != null) {
                                             player.sendMessage(message)
+                                            showParticle(getIndicationLocation(receiver.cords, player.world), player.world)
+
                                         }else{
                                             main.server.consoleSender.sendMessage(message)
                                         }


### PR DESCRIPTION
The current behvior of `listener.kt/checkInventory` is to give a message when a receiver chest is detected that does not have an item frame.  When one has a lot of chests, it can be very difficult to identify exactly which one(s) is might be.

This PR changes the behavior to make the affected chest sparkle for a few seconds, so it can be easier to see which one needs an item frame.